### PR TITLE
Add RelatedId keys to Bloodseeker and Riley the Cunning heroes.

### DIFF
--- a/cards-manifest.json
+++ b/cards-manifest.json
@@ -392,6 +392,9 @@
         },
         {
           "Id": 394,
+          "RelatedId": [
+            601
+          ],
           "Name": "Bloodseeker",
           "CardType": "Hero",
           "Rarity": "Common",

--- a/cards-manifest.json
+++ b/cards-manifest.json
@@ -2266,6 +2266,9 @@
         },
         {
           "Id": 262,
+          "RelatedId": [
+            313
+          ],
           "Name": "Riley the Cunning",
           "CardType": "Hero",
           "Rarity": "Basic",


### PR DESCRIPTION
Blood Rage now has a relation to Bloodseeker.
No Accident now has a relation to Riley the Cunning.

Noticed these were missing when I was manipulating data in my personal project.