### PR TITLE
cards-manifest: Use correct set name.

### DIFF
--- a/cards-manifest.json
+++ b/cards-manifest.json
@@ -1,7 +1,7 @@
 {
   "Sets": [
     {
-      "Name": "Base",
+      "Name": "Call to Arms",
       "Count": 280,
       "ReleaseDate": "2018-11-28T00:00:00",
       "Cards": [


### PR DESCRIPTION
The first set is actually called "Call to Arms".

https://playartifact.com/news/1714079766522391429

Also, how do you get the 280 "Count" value? You have 300 entries in the cards array, but there are cards missing. For example https://www.artifactfire.com/artifact/cards/march-of-the-machines

The collectible card count is also just 237, according to the Steam market. So the 280 seems incorrect to me in any way.